### PR TITLE
Restore compatibility back to Swift 5.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,3 +9,22 @@ on:
 jobs:
   unit-tests:
      uses: vapor/ci/.github/workflows/run-unit-tests.yml@main
+
+  unit-tests-old:
+    if: ${{ !(github.event.pull_request.draft || false) }}
+    strategy:
+      fail-fast: false
+      matrix:
+        swift-image:
+          - swift:5.5-focal
+          - swift:5.6-focal
+          - swift:5.7-jammy
+    runs-on: ubuntu-latest
+    container: ${{ matrix.swift-image }}
+    timeout-minutes: 60
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Run unit tests
+        run: SWIFT_DETERMINISTIC_HASHING=1 swift test --sanitize=thread
+    

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.7
+// swift-tools-version:5.5
 import PackageDescription
 
 let package = Package(


### PR DESCRIPTION
There was no reason for the minimum Swift version to be bumped so high, let's put it back down to 5.5. This should also allow the Vapor toolbox to retain compatibility with Xcode 13.2.